### PR TITLE
refactor: revamp & improve error handling

### DIFF
--- a/src/auth/routes/login.rs
+++ b/src/auth/routes/login.rs
@@ -7,8 +7,8 @@ use crate::auth::access_token::AccessToken;
 use crate::auth::token::Token;
 use crate::auth::user::User;
 use crate::db::DB;
-use crate::error::HResult;
 use crate::error::macros::err;
+use crate::error::HResult;
 use crate::util::use_display;
 
 #[derive(Deserialize, ToSchema)]
@@ -43,11 +43,7 @@ pub struct LoginResponese {
     tag = "identity"
 )]
 #[post("/auth/login")]
-pub async fn login(
-    db: DB,
-    creds: Json<LoginRequest>,
-    req: HttpRequest,
-) -> HResult<HttpResponse> {
+pub async fn login(db: DB, creds: Json<LoginRequest>, req: HttpRequest) -> HResult<HttpResponse> {
     let user_agent = match req.headers().get("User-Agent") {
         Some(user_agent) => match user_agent.to_str() {
             Ok(user_agent) => user_agent,

--- a/src/auth/routes/login.rs
+++ b/src/auth/routes/login.rs
@@ -1,5 +1,5 @@
 use actix_web::post;
-use actix_web::{error::ErrorForbidden, web::Json, Error, HttpRequest, HttpResponse};
+use actix_web::{web::Json, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -7,6 +7,8 @@ use crate::auth::access_token::AccessToken;
 use crate::auth::token::Token;
 use crate::auth::user::User;
 use crate::db::DB;
+use crate::error::HResult;
+use crate::error::macros::err;
 use crate::util::use_display;
 
 #[derive(Deserialize, ToSchema)]
@@ -45,7 +47,7 @@ pub async fn login(
     db: DB,
     creds: Json<LoginRequest>,
     req: HttpRequest,
-) -> Result<HttpResponse, Error> {
+) -> HResult<HttpResponse> {
     let user_agent = match req.headers().get("User-Agent") {
         Some(user_agent) => match user_agent.to_str() {
             Ok(user_agent) => user_agent,
@@ -60,7 +62,7 @@ pub async fn login(
 
     use crate::auth::token_issuing::IssueRefreshTokenResult::*;
     match auth_result {
-        Failure => Err(ErrorForbidden("access_denied")),
+        Failure => err!(403)?,
         Success {
             user,
             access_token,

--- a/src/auth/routes/logout.rs
+++ b/src/auth/routes/logout.rs
@@ -1,6 +1,6 @@
-use actix_web::{get, Error, HttpResponse};
+use actix_web::{get, HttpResponse};
 
-use crate::auth::access_token::AccessToken;
+use crate::{auth::access_token::AccessToken, error::HResult};
 
 /// Log out
 ///
@@ -13,7 +13,7 @@ use crate::auth::access_token::AccessToken;
     security(("token" = []))
 )]
 #[get("/auth/logout")]
-pub async fn logout(_token: AccessToken) -> Result<HttpResponse, Error> {
+pub async fn logout(_token: AccessToken) -> HResult<HttpResponse> {
     // todo: invalidate token
     Ok(HttpResponse::Ok().body("success"))
 }

--- a/src/auth/routes/register.rs
+++ b/src/auth/routes/register.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
 use actix_web::{
-    error::{ErrorBadRequest, ErrorConflict, ErrorInternalServerError},
     post,
     web::Json,
-    Error, HttpResponse,
+    HttpResponse,
 };
 use lazy_static::lazy_static;
 use log::warn;
@@ -13,7 +12,7 @@ use rand::Rng;
 use serde::Deserialize;
 use utoipa::ToSchema;
 
-use crate::{auth::user::User, db::DB};
+use crate::{auth::user::User, db::DB, error::{HResult, macros::err}};
 
 lazy_static! {
     pub static ref EMAIL_REGEX: regex::Regex = regex::Regex::new(r"(?i)^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$").unwrap();
@@ -43,13 +42,13 @@ pub struct RegisterRequest {
     tag = "identity"
 )]
 #[post("/auth/register")]
-pub async fn register(db: DB, req: Json<RegisterRequest>) -> Result<HttpResponse, Error> {
+pub async fn register(db: DB, req: Json<RegisterRequest>) -> HResult<HttpResponse> {
     if !USERNAME_REGEX.is_match(&req.username) {
-        return Err(ErrorBadRequest("invalid_username"));
+        err!(400, "That username contains illegal characters.")?;
     }
 
     if !EMAIL_REGEX.is_match(&req.email) {
-        return Err(ErrorBadRequest("invalid_email"));
+        err!(400, "Invalid email address for registration.")?;
     }
 
     let user = Arc::new(User {
@@ -64,13 +63,13 @@ pub async fn register(db: DB, req: Json<RegisterRequest>) -> Result<HttpResponse
         Ok(did_create) => {
             if !did_create {
                 // user already exists
-                return Err(ErrorConflict("already_exists"));
+                err!(409, "That username is already taken.")?;
             }
             return Ok(HttpResponse::Ok().body("success"));
         }
         Err(e) => {
             warn!("Failed to create user: {}", e);
-            return Err(ErrorInternalServerError("failed"));
+            err!()
         }
     }
 }

--- a/src/auth/routes/register.rs
+++ b/src/auth/routes/register.rs
@@ -1,10 +1,6 @@
 use std::sync::Arc;
 
-use actix_web::{
-    post,
-    web::Json,
-    HttpResponse,
-};
+use actix_web::{post, web::Json, HttpResponse};
 use lazy_static::lazy_static;
 use log::warn;
 use nanoid::nanoid;
@@ -12,7 +8,11 @@ use rand::Rng;
 use serde::Deserialize;
 use utoipa::ToSchema;
 
-use crate::{auth::user::User, db::DB, error::{HResult, macros::err}};
+use crate::{
+    auth::user::User,
+    db::DB,
+    error::{macros::err, HResult},
+};
 
 lazy_static! {
     pub static ref EMAIL_REGEX: regex::Regex = regex::Regex::new(r"(?i)^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$").unwrap();

--- a/src/auth/routes/reissue.rs
+++ b/src/auth/routes/reissue.rs
@@ -1,8 +1,4 @@
-use actix_web::{
-    post,
-    web::Json,
-    HttpRequest,
-};
+use actix_web::{post, web::Json, HttpRequest};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 

--- a/src/auth/routes/reissue.rs
+++ b/src/auth/routes/reissue.rs
@@ -1,5 +1,4 @@
 use actix_web::{
-    error::{Error, ErrorForbidden},
     post,
     web::Json,
     HttpRequest,
@@ -10,6 +9,7 @@ use utoipa::ToSchema;
 use crate::{
     auth::{access_token::AccessToken, token::Token},
     db::DB,
+    error::{macros::err, HResult},
     util::use_display,
 };
 
@@ -45,14 +45,8 @@ pub async fn reissue(
     db: DB,
     body: Json<ReissueRequest>,
     req: HttpRequest,
-) -> Result<Json<ReissueResponse>, Error> {
-    let refresh_token: Token = body.refresh_token.parse().map_err(|e| {
-        use crate::auth::token::TokenParseError::*;
-        match e {
-            InvalidFormat => ErrorForbidden("access_denied"),
-            Expired => ErrorForbidden("token_expired"),
-        }
-    })?;
+) -> HResult<Json<ReissueResponse>> {
+    let refresh_token: Token = body.refresh_token.parse()?;
 
     if refresh_token.is_bot() {
         // for bots, just issue a new access token without invalidating the old refresh token
@@ -81,6 +75,6 @@ pub async fn reissue(
             access_token,
             refresh_token,
         })),
-        Failure => Err(ErrorForbidden("access_denied")),
+        Failure => err!(403)?,
     }
 }

--- a/src/channels/routes/create_channel.rs
+++ b/src/channels/routes/create_channel.rs
@@ -1,20 +1,20 @@
 use actix_web::{
-    error::{ErrorBadRequest, ErrorForbidden, ErrorInternalServerError},
     post,
     web::{Data, Json},
-    Error,
 };
 use lazy_static::lazy_static;
-use log::warn;
 use nanoid::nanoid;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::guilds::routes::GuildIdParams;
 use crate::{
     auth::access_token::AccessToken, channels::channel::ChannelType, db::DB,
     guilds::routes::GuildPath, realtime::pubsub::consumer_manager::EventConsumerManager,
+};
+use crate::{
+    error::{macros::err, HResult},
+    guilds::routes::GuildIdParams,
 };
 
 #[derive(Deserialize, ToSchema)]
@@ -58,24 +58,15 @@ async fn create_channel(
     req: Json<CreateChannelRequest>,
     path: GuildPath,
     ecm: Data<EventConsumerManager>,
-) -> Result<Json<CreateChannelResponse>, Error> {
-    let user_in_guild = db
-        .is_user_in_guild(&token.user_id, &path.guild_id)
-        .await
-        .map_err(|e| {
-            warn!(
-                "failed to check if user {} is in guild {}: {}",
-                token.user_id, path.guild_id, e
-            );
-            ErrorInternalServerError("")
-        })?;
+) -> HResult<Json<CreateChannelResponse>> {
+    let user_in_guild = db.is_user_in_guild(&token.user_id, &path.guild_id).await?;
 
     if !user_in_guild {
-        return Err(ErrorForbidden("access_denied"));
+        err!(403)?
     }
 
     if req.name.trim().is_empty() || !CHANNEL_NAME_REGEX.is_match(&req.name) {
-        return Err(ErrorBadRequest("invalid_name"));
+        err!(400, "The channel name is invalid.")?
     }
 
     let channel_id = sqlx::query!(
@@ -86,11 +77,7 @@ async fn create_channel(
         req.r#type as ChannelType
     )
     .fetch_one(&db.pool)
-    .await
-    .map_err(|e| {
-        warn!("failed to create channel: {}", e);
-        ErrorInternalServerError("")
-    })?
+    .await?
     .id;
 
     ecm.notify_guild_channel_list_update(&path.guild_id).await;

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,21 +120,21 @@ pub trait IntoHandlerErrorResult<T> {
 
 impl<T, E> IntoHandlerErrorResult<T> for Result<T, E> {
     fn or_err(self, code: u16) -> Result<T, HandlerError> {
-        Err(code.into())
+        self.or(Err(code.into()))
     }
 
     fn or_err_msg(self, code: u16, message: &'static str) -> Result<T, HandlerError> {
-        Err(HandlerError::from((code, message)))
+        self.or(Err(HandlerError::from((code, message))))
     }
 }
 
 impl<T> IntoHandlerErrorResult<T> for Option<T> {
     fn or_err(self, code: u16) -> Result<T, HandlerError> {
-        Err(code.into())
+        self.ok_or(code.into())
     }
 
     fn or_err_msg(self, code: u16, message: &'static str) -> Result<T, HandlerError> {
-        Err(HandlerError::from((code, message)))
+        self.ok_or(HandlerError::from((code, message)))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -141,11 +141,11 @@ impl<T> IntoHandlerErrorResult<T> for Option<T> {
 pub mod macros {
     /// Convenience macro to return a `HandlerError`` wrapped in an `Err()``.
     /// Use it whenever you want to return an error from a handler function.
-    /// 
+    ///
     /// Example:
     /// ```
     /// use crate::error::macros::err;
-    /// 
+    ///
     /// fn handler() -> HResult<()> {
     ///    // Returns HTTP 500 Internal Server Error
     ///    err!()?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,127 @@
+use actix_web::{http::StatusCode, HttpResponse, ResponseError};
+use derive_more::{Display, Error};
+use log::error;
+use serde::Serialize;
+
+use crate::auth::token::TokenParseError;
+
+pub type HResult<T> = std::result::Result<T, HandlerError>;
+
+#[derive(Debug, Display, Error, Serialize)]
+#[display(fmt = "{}", message)]
+pub struct HandlerError {
+    pub message: String,
+    pub code: u16,
+}
+
+impl HandlerError {
+    pub fn with_code(code: u16, message: String) -> Self {
+        Self { message, code }
+    }
+
+    pub fn internal_error() -> Self {
+        Self::with_code(500, "Internal Server Error".into())
+    }
+}
+
+impl ResponseError for HandlerError {
+    fn status_code(&self) -> StatusCode {
+        StatusCode::from_u16(self.code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        HttpResponse::build(self.status_code()).json(self)
+    }
+}
+
+impl From<sqlx::Error> for HandlerError {
+    fn from(err: sqlx::Error) -> Self {
+        error!("database error: {}", err);
+        Self::internal_error()
+    }
+}
+
+impl From<u16> for HandlerError {
+    fn from(code: u16) -> Self {
+        let message = match code {
+            403 => "Access denied".into(),
+            401 => "Authorization required".into(),
+            _ => StatusCode::from_u16(code)
+                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+                .to_string(),
+        };
+
+        Self::with_code(code, message)
+    }
+}
+
+impl From<&str> for HandlerError {
+    fn from(message: &str) -> Self {
+        Self::with_code(500, message.into())
+    }
+}
+
+impl From<String> for HandlerError {
+    fn from(message: String) -> Self {
+        Self::with_code(500, message)
+    }
+}
+
+impl From<(u16, &'static str)> for HandlerError {
+    fn from(tuple: (u16, &'static str)) -> Self {
+        Self::with_code(tuple.0, tuple.1.into())
+    }
+}
+
+impl From<TokenParseError> for HandlerError {
+    fn from(err: TokenParseError) -> Self {
+        use TokenParseError::*;
+        match err {
+            InvalidFormat => Self::with_code(403, "Invalid token supplied.".into()),
+            Expired => Self::with_code(403, "The supplied token has expired.".into()),
+        }
+    }
+}
+
+
+pub trait IntoHandlerErrorResult<T> {
+    fn or_err(self, code: u16) -> Result<T, HandlerError>;
+    fn or_err_msg(self, code: u16, message: &'static str) -> Result<T, HandlerError>;
+}
+
+impl<T, E> IntoHandlerErrorResult<T> for Result<T, E> {
+    fn or_err(self, code: u16) -> Result<T, HandlerError> {
+        Err(code.into())
+    }
+
+    fn or_err_msg(self, code: u16, message: &'static str) -> Result<T, HandlerError> {
+        Err(HandlerError::from((code, message)))
+    }
+}
+
+impl<T> IntoHandlerErrorResult<T> for Option<T> {
+    fn or_err(self, code: u16) -> Result<T, HandlerError> {
+        Err(code.into())
+    }
+
+    fn or_err_msg(self, code: u16, message: &'static str) -> Result<T, HandlerError> {
+        Err(HandlerError::from((code, message)))
+    }
+}
+
+
+pub mod macros {
+macro_rules! err {
+    ($code:expr, $msg:expr) => {
+        Err(crate::error::HandlerError::from(($code, $msg.into())))
+    };
+    ($code:expr) => {
+        Err(crate::error::HandlerError::from($code))
+    };
+    () => {
+        Err(crate::error::HandlerError::internal_error())
+    };
+}
+
+    pub(crate) use err;
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,15 @@ use crate::auth::token::TokenParseError;
 
 pub type HResult<T> = std::result::Result<T, HandlerError>;
 
+/// A custom error type that should be used for all errors that occur in the
+/// route handler functions. This type implements `ResponseError` and can be
+/// returned from a handler function to send an error response to the client.
+///
+/// Conveniently, this type implements `From` for `sqlx::Error` and `u16` to
+/// make it easy to return an error from a database query or a status code.
+///
+/// It is recommended that you use the `err!` macro to return an error from a
+/// handler function. This macro is re-exported from this module.
 #[derive(Debug, Display, Error, Serialize)]
 #[display(fmt = "{}", message)]
 pub struct HandlerError {
@@ -83,7 +92,27 @@ impl From<TokenParseError> for HandlerError {
     }
 }
 
-
+/// Trait to facilitate the conversion between `Result` and `Option` into a
+/// `HandlerError`. Useful when you have a `Result` or `Option` and want to
+/// return an error if it is `None` or `Err`.
+///
+/// Example:
+/// ```
+///
+/// fn handler(number: &str, double: &str) -> HResult<i32> {
+///     //                                    ~~~~~~~~~~~~ use when possible
+///     // Returns HTTP 400 Bad Request
+///     let mut number: i32 = number.parse().or_err(400)?;
+///     // Returns HTTP 400 Bad Request with a custom message
+///     let double: bool = double.parse().or_err_msg(400, "must be true or false")?;
+///
+///     if double {
+///         number *= 2;
+///     }
+///
+///     Ok(number)
+/// }
+/// ```
 pub trait IntoHandlerErrorResult<T> {
     fn or_err(self, code: u16) -> Result<T, HandlerError>;
     fn or_err_msg(self, code: u16, message: &'static str) -> Result<T, HandlerError>;
@@ -109,19 +138,40 @@ impl<T> IntoHandlerErrorResult<T> for Option<T> {
     }
 }
 
-
 pub mod macros {
-macro_rules! err {
-    ($code:expr, $msg:expr) => {
-        Err(crate::error::HandlerError::from(($code, $msg.into())))
-    };
-    ($code:expr) => {
-        Err(crate::error::HandlerError::from($code))
-    };
-    () => {
-        Err(crate::error::HandlerError::internal_error())
-    };
-}
+    /// Convenience macro to return a `HandlerError`` wrapped in an `Err()``.
+    /// Use it whenever you want to return an error from a handler function.
+    /// 
+    /// Example:
+    /// ```
+    /// use crate::error::macros::err;
+    /// 
+    /// fn handler() -> HResult<()> {
+    ///    // Returns HTTP 500 Internal Server Error
+    ///    err!()?;
+    ///    
+    ///    // Returns HTTP 403 Forbidden
+    ///    err!(403)?;
+    ///    
+    ///    // Returns HTTP 403 Forbidden with a custom message
+    ///    err!(403, "You shall not pass!")?;
+    ///    
+    ///    // Returns HTTP 500 Internal Server Error with a custom message
+    ///    err!("A rat chewed through the ethernet cable")?;
+    ///    
+    ///    Ok(())
+    /// }
+    macro_rules! err {
+        ($code:expr, $msg:expr) => {
+            Err(crate::error::HandlerError::from(($code, $msg.into())))
+        };
+        ($code:expr) => {
+            Err(crate::error::HandlerError::from($code))
+        };
+        () => {
+            Err(crate::error::HandlerError::internal_error())
+        };
+    }
 
     pub(crate) use err;
 }

--- a/src/guilds/routes/join_guild.rs
+++ b/src/guilds/routes/join_guild.rs
@@ -62,7 +62,7 @@ pub async fn join_guild(
         err!()?;
     }
     ecm.notify_guild_member_list_update(&req.guild_id).await;
-    
+
     // again, this is temporarily here so the browser redirects back to /
     Ok(Redirect::to("/").see_other())
 }

--- a/src/guilds/routes/join_guild.rs
+++ b/src/guilds/routes/join_guild.rs
@@ -1,17 +1,18 @@
 #![allow(deprecated)]
 
 use actix_web::{
-    error::{ErrorBadRequest, ErrorInternalServerError},
     get,
     web::{Data, Redirect},
     Responder,
 };
-use log::warn;
 
-use crate::guilds::routes::GuildIdParams;
 use crate::{
     auth::access_token::AccessToken, db::DB, guilds::routes::GuildPath,
     realtime::pubsub::consumer_manager::EventConsumerManager,
+};
+use crate::{
+    error::{macros::err, HResult},
+    guilds::routes::GuildIdParams,
 };
 
 // todo: phase this out for invite system. btw, this is GET so people can go in
@@ -41,7 +42,7 @@ pub async fn join_guild(
     token: AccessToken,
     req: GuildPath,
     ecm: Data<EventConsumerManager>,
-) -> Result<impl Responder, actix_web::Error> {
+) -> HResult<impl Responder> {
     let rows_affected = sqlx::query!(
         r#"
             INSERT INTO members (user_id, guild_id) 
@@ -54,20 +55,14 @@ pub async fn join_guild(
         req.guild_id
     )
     .execute(&db.pool)
-    .await
-    .map_err(|e| {
-        warn!(
-            "user {} failed to join guild {}: {}",
-            token.user_id, req.guild_id, e
-        );
-        ErrorInternalServerError("failed")
-    })?
+    .await?
     .rows_affected();
 
     if rows_affected == 0 {
-        return Err(ErrorBadRequest("join_invalid"));
+        err!()?;
     }
     ecm.notify_guild_member_list_update(&req.guild_id).await;
+    
     // again, this is temporarily here so the browser redirects back to /
     Ok(Redirect::to("/").see_other())
 }

--- a/src/guilds/routes/update_guild.rs
+++ b/src/guilds/routes/update_guild.rs
@@ -1,13 +1,13 @@
 use actix_web::{put, HttpResponse};
 
-use crate::{auth::access_token::AccessToken, db::DB, guilds::routes::GuildPath};
+use crate::{auth::access_token::AccessToken, db::DB, guilds::routes::GuildPath, error::HResult};
 
 #[put("/guilds/{guild_id}")]
 pub async fn update_guild(
     _db: DB,
     _token: AccessToken,
     _req: GuildPath,
-) -> Result<HttpResponse, actix_web::Error> {
+) -> HResult<HttpResponse> {
     // todo: do this
     Ok(HttpResponse::NotImplemented().body("not_implemented"))
 }

--- a/src/guilds/routes/update_guild.rs
+++ b/src/guilds/routes/update_guild.rs
@@ -1,13 +1,9 @@
 use actix_web::{put, HttpResponse};
 
-use crate::{auth::access_token::AccessToken, db::DB, guilds::routes::GuildPath, error::HResult};
+use crate::{auth::access_token::AccessToken, db::DB, error::HResult, guilds::routes::GuildPath};
 
 #[put("/guilds/{guild_id}")]
-pub async fn update_guild(
-    _db: DB,
-    _token: AccessToken,
-    _req: GuildPath,
-) -> HResult<HttpResponse> {
+pub async fn update_guild(_db: DB, _token: AccessToken, _req: GuildPath) -> HResult<HttpResponse> {
     // todo: do this
     Ok(HttpResponse::NotImplemented().body("not_implemented"))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod bot;
 mod channels;
 mod crypto;
 mod db;
+mod error;
 mod guilds;
 mod media;
 mod messaging;
@@ -30,7 +31,6 @@ mod realtime;
 mod security;
 mod settings;
 mod util;
-mod error;
 mod voice;
 
 // shortcut to make a Mutexed String to T hashmap

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod realtime;
 mod security;
 mod settings;
 mod util;
+mod error;
 mod voice;
 
 // shortcut to make a Mutexed String to T hashmap

--- a/src/options.rs
+++ b/src/options.rs
@@ -173,7 +173,7 @@ pub fn ssl_bind_addr() -> (IpAddr, u16) {
 }
 
 /// Load the SSL certificate and key files into a rustls config object
-/// 
+///
 /// Taken from https://github.com/actix/examples/blob/master/https-tls/rustls/src/main.rs
 pub fn ssl_config() -> rustls::ServerConfig {
     // init server config builder with safe defaults
@@ -239,7 +239,7 @@ pub fn initialize_all() {
     }
 
     lazy_static::initialize(&BIND_ADDR);
-    
+
     lazy_static::initialize(&SSL_BIND_ADDR);
     lazy_static::initialize(&SSL_CERT_PATH);
     lazy_static::initialize(&SSL_KEY_PATH);

--- a/src/voice/routes/leave_vc.rs
+++ b/src/voice/routes/leave_vc.rs
@@ -1,6 +1,9 @@
 use actix_web::{get, web::Data, HttpResponse};
 
-use crate::{voice::{client::VoiceClientEx, VoiceChannels, VoiceClients}, error::HResult};
+use crate::{
+    error::HResult,
+    voice::{client::VoiceClientEx, VoiceChannels, VoiceClients},
+};
 
 /// Leave voice chat
 ///

--- a/src/voice/routes/leave_vc.rs
+++ b/src/voice/routes/leave_vc.rs
@@ -1,6 +1,6 @@
-use actix_web::{get, web::Data, Error, HttpResponse};
+use actix_web::{get, web::Data, HttpResponse};
 
-use crate::voice::{client::VoiceClientEx, VoiceChannels, VoiceClients};
+use crate::{voice::{client::VoiceClientEx, VoiceChannels, VoiceClients}, error::HResult};
 
 /// Leave voice chat
 ///
@@ -19,7 +19,7 @@ pub async fn leave_vc(
     client: VoiceClientEx,
     clients: Data<VoiceClients>,
     channels: Data<VoiceChannels>,
-) -> Result<HttpResponse, Error> {
+) -> HResult<HttpResponse> {
     client
         .channel
         .disconnect_client(&client, &clients, &channels)

--- a/src/voice/routes/voice_events.rs
+++ b/src/voice/routes/voice_events.rs
@@ -12,6 +12,7 @@ use serde_json::json;
 
 use crate::{
     auth::user::PublicUserInfo,
+    error::macros::err,
     realtime::socket::{SendFailureReason, Socket},
     voice::{
         channel::VoiceChannel,
@@ -93,7 +94,7 @@ pub async fn voice_events_ws(
     body: Payload,
 ) -> Result<HttpResponse, Error> {
     if client.socket.read().unwrap().is_some() {
-        return Err(actix_web::error::ErrorBadRequest("already_connected"));
+        err!(400, "Already connected to a voice event socket.")?;
     }
 
     // this is ugly but needed so the `move` callbacks below can access the client


### PR DESCRIPTION
No more `map_err` and unnecessarily long code for error handling.
`HandlerError` and `HResult<T>` provide error types to be used universally thoughout handlers.

Error format the API caller sees:
```json
{
	"code": 401,
	"message": "Authorization required"
}
```

`.or_err` helper for any `Result<T, E>` or `Option<T>`:
```rust
fn handler(number: &str, double: &str) -> HResult<T> {
    //                                    ~~~~~~~~~~~~ replaces Result<T, actix_web::Error>
    
	// Returns HTTP 400 Bad Request
    let mut number: i32 = number.parse().or_err(400)?;
    
	// Returns HTTP 400 Bad Request with a custom message
    let double: bool = double.parse().or_err_msg(400, "must be true or false")?;
    
	// ...
}
```

`err!` macro for creating `HandlerError`s quickly:
```rust
use crate::error::macros::err;

fn handler() -> HResult<()> {
    // Returns HTTP 500 Internal Server Error
    err!()?;

    // Returns HTTP 403 Forbidden
    err!(403)?;

    // Returns HTTP 403 Forbidden with a custom message
    err!(403, "You shall not pass!")?;

    // Returns HTTP 500 Internal Server Error with a custom message
    err!("A rat chewed through the ethernet cable")?;

    Ok(())
}
```